### PR TITLE
Exclude python 3.9 for milestone in sanity test matrix

### DIFF
--- a/.github/workflows/sanity.yml
+++ b/.github/workflows/sanity.yml
@@ -54,6 +54,10 @@ jobs:
               "python-version": "3.8"
             },
             {
+              "ansible-version": "milestone",
+              "python-version": "3.9"
+            },
+            {
               "ansible-version": "devel",
               "python-version": "3.7"
             },

--- a/.github/workflows/sanity.yml
+++ b/.github/workflows/sanity.yml
@@ -1,3 +1,4 @@
+---
 name: Sanity
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.yamllint
+++ b/.yamllint
@@ -1,0 +1,20 @@
+---
+extends: default
+
+rules:
+  braces:
+    max-spaces-inside: 1
+    level: error
+  brackets:
+    max-spaces-inside: 1
+    level: error
+  document-start: disable
+  line-length: disable
+  truthy: disable
+  indentation:
+    spaces: 2
+    indent-sequences: consistent
+ignore: |
+  .cache
+  .tox
+  tests/output

--- a/changelogs/changelog.yaml
+++ b/changelogs/changelog.yaml
@@ -1,0 +1,3 @@
+---
+ancestor: null
+releases: {}

--- a/changelogs/config.yaml
+++ b/changelogs/config.yaml
@@ -1,0 +1,32 @@
+---
+changelog_filename_template: ../CHANGELOG.rst
+changelog_filename_version_depth: 0
+changes_file: changelog.yaml
+changes_format: combined
+keep_fragments: false
+mention_ancestor: true
+new_plugins_after_name: removed_features
+notesdir: fragments
+prelude_section_name: release_summary
+prelude_section_title: Release Summary
+sanitize_changelog: true
+sections:
+  - - major_changes
+    - Major Changes
+  - - minor_changes
+    - Minor Changes
+  - - breaking_changes
+    - Breaking Changes / Porting Guide
+  - - deprecated_features
+    - Deprecated Features
+  - - removed_features
+    - Removed Features (previously deprecated)
+  - - security_fixes
+    - Security Fixes
+  - - bugfixes
+    - Bugfixes
+  - - known_issues
+    - Known Issues
+title: cloud.gcp_ops
+trivial_section_name: trivial
+use_fqcn: true

--- a/changelogs/fragments/20230824-update-ci-sanity-test-matrix.yaml
+++ b/changelogs/fragments/20230824-update-ci-sanity-test-matrix.yaml
@@ -1,5 +1,0 @@
----
-trivial:
-  - Add changelogs directory and config (https://github.com/redhat-cop/cloud.gcp_ops/pull/6).
-  - Add tests directory (https://github.com/redhat-cop/cloud.gcp_ops/pull/6).
-  - Add milestone/python 3.9 to the sanity test exclude matrix since 3.9 is no longer supported in milestone (https://github.com/redhat-cop/cloud.gcp_ops/pull/6).

--- a/changelogs/fragments/20230824-update-ci-sanity-test-matrix.yaml
+++ b/changelogs/fragments/20230824-update-ci-sanity-test-matrix.yaml
@@ -1,0 +1,5 @@
+---
+trivial:
+  - Add changelogs directory and config (https://github.com/redhat-cop/cloud.gcp_ops/pull/6).
+  - Add tests directory (https://github.com/redhat-cop/cloud.gcp_ops/pull/6).
+  - Add milestone/python 3.9 to the sanity test exclude matrix since 3.9 is no longer supported in milestone (https://github.com/redhat-cop/cloud.gcp_ops/pull/6).

--- a/tests/.placeholder
+++ b/tests/.placeholder
@@ -1,0 +1,1 @@
+Placeholder file to ensure directory remains checked into git. Please delete when tests are added.


### PR DESCRIPTION
##### SUMMARY
The milestone and devel branches of ansible no longer support python 3.9. This PR adds milestone/python 3.9 to `matrix_exclude` in the sanity test Github Actions workflow.

##### ISSUE TYPE
- Bugfix Pull Request