### PR TITLE
Update version to point to the next major release in the galaxy.yml file

### DIFF
--- a/galaxy.yml
+++ b/galaxy.yml
@@ -8,7 +8,7 @@ issues: https://github.com/ansible-collections/cloud.gcp_ops/issues
 license_file: LICENSE
 namespace: cloud
 name: gcp_ops
-version: 1.0.0
+version: 3.0.0-dev0
 readme: README.md
 repository: https://github.com/ansible-collections/cloud.aws_gcp
 tags:


### PR DESCRIPTION
Since stable-2 has been created, update the galaxy.yml version to 3.0.0-dev0.